### PR TITLE
Do not call the rate limiting api for every request

### DIFF
--- a/aiogithubapi/__init__.py
+++ b/aiogithubapi/__init__.py
@@ -1,5 +1,5 @@
 """Async Github API implementation."""
-from aiogithubapi.const import BASE_HEADERS, BASE_URL, GOOD_HTTP_CODES
+from aiogithubapi.const import BASE_HEADERS, BASE_URL, GOOD_HTTP_CODES, RATELIMIT_HTTP_CODE
 from aiogithubapi.exceptions import (
     AIOGitHubAuthentication,
     AIOGitHubException,

--- a/aiogithubapi/const.py
+++ b/aiogithubapi/const.py
@@ -5,3 +5,5 @@ BASE_HEADERS = {
     "User-Agent": "python/AIOGitHub",
 }
 GOOD_HTTP_CODES = [200, 201, 202, 203]
+
+RATELIMIT_HTTP_CODE = 403

--- a/aiogithubapi/ratelimit.py
+++ b/aiogithubapi/ratelimit.py
@@ -6,13 +6,11 @@ https://developer.github.com/v3/rate_limit/
 # pylint: disable=missing-docstring
 from datetime import datetime
 
-
 class RateLimitResources:
     """Ratelimit resources."""
 
-    def __init__(self, rate_data):
+    def __init__(self):
         """Initialize."""
-        self.rate_data = rate_data
         self.limit = None
         self.remaining = None
         self.reset = None
@@ -24,6 +22,15 @@ class RateLimitResources:
             return None
         return datetime.utcfromtimestamp(self.reset)
 
+    def load_from_resp(self, hdrs):
+        self.limit = hdrs['X-RateLimit-Limit']
+        self.remaining = hdrs['X-RateLimit-Remaining']
+        self.reset = int(hdrs['X-RateLimit-Reset'])
+    def load_from_json(self, data):
+        self.limit = data.get("limit")
+        self.remaining = data.get("remaining")
+        self.reset = data.get("reset")
+
 
 class AIOGithubRateLimits:
     """Remainding Ratelimits."""
@@ -31,14 +38,19 @@ class AIOGithubRateLimits:
     def __init__(self, attributes):
         """Initialize."""
         self.attributes = attributes
-        self.core = RateLimitResources(attributes.get("resources", {}).get("core"))
-        self.search = RateLimitResources(attributes.get("resources", {}).get("search"))
-        self.graphql = RateLimitResources(
-            attributes.get("resources", {}).get("graphql")
-        )
-        self.integration_manifest = RateLimitResources(
-            attributes.get("resources", {}).get("integration_manifest")
-        )
+        resources = attributes.get("resources", {})
+
+        self.core = RateLimitResources()
+        self.core.load_from_json(resources.get("core"))
+
+        self.search = RateLimitResources()
+        self.search.load_from_json(resources.get("search"))
+
+        self.graphql = RateLimitResources()
+        self.graphql.load_from_json(resources.get("graphql"))
+
+        self.integration_manifest = RateLimitResources()
+        self.integration_manifest.load_from_json(resources.get("integration_manifest"))
 
     @property
     def limit(self):
@@ -54,7 +66,4 @@ class AIOGithubRateLimits:
 
     @property
     def reset_utc(self):
-        """Return date + time in UTC for next reset."""
-        if self.reset is None:
-            return None
-        return datetime.utcfromtimestamp(self.reset)
+        return self.core.reset_utc

--- a/aiogithubapi/repository.py
+++ b/aiogithubapi/repository.py
@@ -15,6 +15,7 @@ import backoff
 from aiogithubapi import (
     BASE_URL,
     GOOD_HTTP_CODES,
+    RATELIMIT_HTTP_CODE,
     AIOGitHub,
     AIOGithubRepositoryContent,
     AIOGithubTreeContent,
@@ -83,12 +84,12 @@ class AIOGithubRepository(AIOGitHub):
         if ref is not None:
             params["ref"] = ref.replace("tags/", "")
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.get(url, headers=self.headers, params=params)
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
             response = await response.json()
@@ -116,14 +117,14 @@ class AIOGithubRepository(AIOGitHub):
             raise AIOGitHubException("Missing ref")
         url = f"{BASE_URL}/repos/{self.full_name}/git/trees/{ref}"
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.get(
                 url, headers=self.headers, params={"recursive": "1"}
             )
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
             response = await response.json()
@@ -144,10 +145,6 @@ class AIOGithubRepository(AIOGitHub):
         if ref is not None:
             params["ref"] = ref.replace("tags/", "")
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         headers = {}
         for header in self.headers:
             headers[header] = self.headers[header]
@@ -155,6 +152,10 @@ class AIOGithubRepository(AIOGitHub):
 
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.get(url, headers=headers, params=params)
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
             response = await response.text()
@@ -169,12 +170,12 @@ class AIOGithubRepository(AIOGitHub):
         endpoint = "/repos/{}/releases".format(self.full_name)
         url = BASE_URL + endpoint
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.get(url, headers=self.headers)
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
             response = await response.json()
@@ -203,12 +204,12 @@ class AIOGithubRepository(AIOGitHub):
         endpoint = "/repos/" + self.full_name + "/commits/" + self.default_branch
         url = BASE_URL + endpoint
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.get(url, headers=self.headers)
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
 
@@ -227,12 +228,12 @@ class AIOGithubRepository(AIOGitHub):
         endpoint = f"/repos/{self.full_name}/issues/{issue}"
         url = BASE_URL + endpoint
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.get(url, headers=self.headers)
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
 
@@ -247,12 +248,12 @@ class AIOGithubRepository(AIOGitHub):
         endpoint = f"/repos/{self.full_name}/issues/{issue}/comments"
         url = BASE_URL + endpoint
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.get(url, headers=self.headers)
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
 
@@ -270,14 +271,14 @@ class AIOGithubRepository(AIOGitHub):
         endpoint = f"/repos/{self.full_name}/issues/{issue}/comments"
         url = BASE_URL + endpoint
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.post(
                 url, headers=self.headers, json={"body": body}
             )
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
 
@@ -289,14 +290,14 @@ class AIOGithubRepository(AIOGitHub):
         endpoint = f"/repos/{self.full_name}/issues/comments/{comment}"
         url = BASE_URL + endpoint
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.patch(
                 url, headers=self.headers, json={"body": body}
             )
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
 
@@ -317,10 +318,6 @@ class AIOGithubRepository(AIOGitHub):
         endpoint = f"/repos/{self.full_name}/issues/{issue}"
         url = BASE_URL + endpoint
 
-        await self.get_ratelimit()
-        if self.ratelimits.remaining is not None and self.ratelimits.remaining == 0:
-            raise AIOGitHubRatelimit("GitHub Ratelimit error")
-
         data = {}
         if title is not None:
             data["title"] = title
@@ -339,6 +336,10 @@ class AIOGithubRepository(AIOGitHub):
 
         async with async_timeout.timeout(20, loop=get_event_loop()):
             response = await self.session.patch(url, headers=self.headers, json=data)
+            self.ratelimits.load_from_resp(response.headers)
+
+            if response.status is RATELIMIT_HTTP_CODE:
+                raise AIOGitHubRatelimit('GitHub Ratelimit error')
             if response.status not in GOOD_HTTP_CODES:
                 raise AIOGitHubException(f"GitHub returned {response.status} for {url}")
 


### PR DESCRIPTION
Hey @ludeeus, I hope this finds you well!

I'm a new-ish Home Assistant / HACS user and started poking around how all of this is implemented; I'm also a GitHub Employee that's worked quite a bit on our API, so I naturally started here!

The big thing I wanted to change was removing the call to `GET /rate_limit` for every request - I don't think it serves a huge purpose when you can make the underlying request and check if you're rate limited via status codes, and when you can load the relevant rate limiting information from response headers when you get the data back anyway. 

Doing this removes an entire round trip to the GitHub API, and shouldn't impact any of the functionality that this library provides. I made sure to keep the `get_ratelimit` method, so that the uses of it in HACS that I saw will still work.

In no way is this an official request from GitHub, but from one happy hass user, these would make this client a better citizen of GitHub's API, and hopefully reduce networking traffic and increase performance for everyone. 

Let me know what you think! I'm happy to make any changes here if anything doesn't look good, and I'm also happy to do any testing to make sure I haven't broken clients of this library upstream.  