### PR TITLE
Add `.unsubscribe_all` and return Tasks from `.unsubscribe`

### DIFF
--- a/aiogithubapi/github.py
+++ b/aiogithubapi/github.py
@@ -109,7 +109,7 @@ class GitHub(GitHubBase):
 
     async def __aexit__(self, *exc_info) -> None:
         """Async exit."""
-        await self.repos.events.stop_all_subscriptions()
+        await self.repos.events.unsubscribe_all()
         await self.close_session()
 
     async def close_session(self) -> None:

--- a/aiogithubapi/github.py
+++ b/aiogithubapi/github.py
@@ -109,6 +109,7 @@ class GitHub(GitHubBase):
 
     async def __aexit__(self, *exc_info) -> None:
         """Async exit."""
+        await self.repos.events.stop_all_subscriptions()
         await self.close_session()
 
     async def close_session(self) -> None:

--- a/aiogithubapi/namespaces/events.py
+++ b/aiogithubapi/namespaces/events.py
@@ -155,7 +155,6 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
         self,
         *,
         subscription_id: str | None = None,
-        wait: bool = True,
     ) -> list[asyncio.Task]:
         """
         Unsubscribe to an event stream
@@ -193,7 +192,7 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
         """Unsubscribe and wait for all subscriptions to be done."""
         if all_tasks := [s["task"] for s in list(self._subscriptions.values())]:
             for subscription_id in list(self._subscriptions):
-                self.unsubscribe(subscription_id=subscription_id, wait=False)
+                self.unsubscribe(subscription_id=subscription_id)
             await asyncio.wait(all_tasks)
 
 

--- a/aiogithubapi/namespaces/events.py
+++ b/aiogithubapi/namespaces/events.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Literal
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Literal, TypedDict
 from uuid import uuid4
 
 from ..const import LOGGER, GitHubRequestKwarg, RepositoryType
@@ -29,6 +29,13 @@ _DEFAULT_BACKOFF = 300
 _DEFAULT_POLL = 60
 
 
+class SubscriptionType(TypedDict):
+    """Custom type for subscriptions."""
+
+    task: asyncio.Task[None]
+    handler: asyncio.TimerHandle[None]
+
+
 class _GitHubEventsBaseNamespace(BaseNamespace):
     """Methods for the events namespace"""
 
@@ -39,7 +46,8 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
     ) -> None:
         super().__init__(client)
         self._space = space
-        self._subscriptions: Dict[str, asyncio.TimerHandle[None]] = {}
+        self._subscriptions: Dict[str, SubscriptionType] = {}
+        self._active_subscriptions: set[str] = set()
 
     @staticmethod
     async def _wait(wait_time: float) -> None:
@@ -83,7 +91,8 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
             _poll_time: int = 60
             _target_time = datetime.utcnow().isoformat()
             LOGGER.debug("Starting event subscription for github.com/%s", name)
-            while subscription_id in self._subscriptions:
+            subscription_task = self._subscriptions[subscription_id]["task"]
+            while not subscription_task.cancelled():
                 try:
                     response = await self._client.async_call_api(
                         endpoint=f"/{self._space}/{name}/events",
@@ -134,8 +143,12 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
             LOGGER.debug("Stopping event subscription for github.com/%s", name)
             self.unsubscribe(subscription_id=subscription_id)
 
-        handler = self._client._loop.call_soon(self._client._loop.create_task, _subscriber())
-        self._subscriptions[subscription_id] = handler
+        subscription_task = self._client._loop.create_task(_subscriber())
+        subscription_handler = self._client._loop.call_soon(subscription_task)
+        self._subscriptions[subscription_id] = {
+            "task": subscription_task,
+            "handler": subscription_handler,
+        }
 
         return subscription_id
 
@@ -149,15 +162,31 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
 
         The ID you got when you subscribed, if omitted all active subscriptions will be stopped.
         """
+
+        def _cancel_subscription(id: str)-> None:
+            if subscription := self._subscriptions.get(id):
+                subscription_handler = subscription["handler"]
+                if not subscription_handler.cancelled():
+                    subscription_handler.cancel()
+
+                subscription_task = subscription["task"]
+                if not subscription_task.cancelled():
+                    subscription_task.cancel()
+
+                del self._subscriptions[id]
+
         if not subscription_id:
+            for subscription_id in list(self._subscriptions.keys()):
+                _cancel_subscription(subscription_id)
+        else:
+            _cancel_subscription(subscription_id)
+
+    async def stop_all_subscriptions(self) -> None:
+        """Unsubscribe and wait for all subscriptions to be done."""
+        if all_tasks := [s["task"] for s in list(self._subscriptions.values())]:
             for subscription_id in list(self._subscriptions):
-                handler = self._subscriptions[subscription_id]
-                handler.cancel()
-                del self._subscriptions[subscription_id]
-            return
-        if handler := self._subscriptions.get(subscription_id):
-            handler.cancel()
-            del self._subscriptions[subscription_id]
+                self.unsubscribe(subscription_id=subscription_id)
+            await asyncio.wait(all_tasks)
 
 
 class GitHubEventsReposNamespace(_GitHubEventsBaseNamespace):

--- a/aiogithubapi/namespaces/events.py
+++ b/aiogithubapi/namespaces/events.py
@@ -188,12 +188,10 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
             if (subscription := self._subscriptions.get(subid)) is not None
         ]
 
-    async def stop_all_subscriptions(self) -> None:
+    async def unsubscribe_all(self) -> None:
         """Unsubscribe and wait for all subscriptions to be done."""
-        if all_tasks := [s["task"] for s in list(self._subscriptions.values())]:
-            for subscription_id in list(self._subscriptions):
-                self.unsubscribe(subscription_id=subscription_id)
-            await asyncio.wait(all_tasks)
+        if tasks := self.unsubscribe():
+            await asyncio.wait(tasks)
 
 
 class GitHubEventsReposNamespace(_GitHubEventsBaseNamespace):

--- a/aiogithubapi/namespaces/events.py
+++ b/aiogithubapi/namespaces/events.py
@@ -166,7 +166,7 @@ class _GitHubEventsBaseNamespace(BaseNamespace):
         The ID you got when you subscribed, if omitted all active subscriptions will be stopped.
         """
 
-        def _cancel_subscription(subid: str, subscription: SubscriptionType) -> asyncio.Task | None:
+        def _cancel_subscription(subid: str, subscription: SubscriptionType) -> asyncio.Task:
             subscription_handler = subscription["handler"]
             if not subscription_handler.cancelled():
                 subscription_handler.cancel()

--- a/tests/namespaces/test_events.py
+++ b/tests/namespaces/test_events.py
@@ -4,10 +4,11 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import aiohttp
 
-from aiogithubapi import GitHubAPI, GitHubEventModel, GitHubRepositoryModel
+from aiogithubapi import GitHubAPI, GitHubEventModel
 
-from tests.common import TEST_REPOSITORY_NAME, MockedRequests, MockResponse
+from tests.common import TEST_REPOSITORY_NAME, TOKEN, MockedRequests, MockResponse
 
 
 @pytest.fixture()
@@ -39,6 +40,62 @@ async def test_subscription(github_api: GitHubAPI, mock_requests: MockedRequests
 
 
 @pytest.mark.asyncio
+async def test_stopping_all_subscriptions(github_api: GitHubAPI, mock_requests: MockedRequests):
+    tasks_before = asyncio.all_tasks(github_api._client._loop)  # This includes the test task
+    assert len(tasks_before) == 1
+
+    event_callback_mock = AsyncMock()
+
+    subscription_id_1 = await github_api.repos.events.subscribe(
+        TEST_REPOSITORY_NAME, event_callback=event_callback_mock
+    )
+    subscription_id_2 = await github_api.repos.events.subscribe(
+        TEST_REPOSITORY_NAME, event_callback=event_callback_mock
+    )
+
+    assert subscription_id_1 in github_api.repos.events._subscriptions
+    assert subscription_id_2 in github_api.repos.events._subscriptions
+    while not event_callback_mock.called:
+        await asyncio.sleep(0)
+
+    event: GitHubEventModel = event_callback_mock.call_args[0][0]
+    assert event.type == "PushEvent"
+
+    assert len(asyncio.all_tasks(github_api._client._loop) - tasks_before) == 2
+
+    await github_api.repos.events.stop_all_subscriptions()
+    assert len(asyncio.all_tasks(github_api._client._loop) - tasks_before) == 0
+
+
+@pytest.mark.asyncio
+async def test_stopping_all_subscriptions_async_with(
+    event_loop: asyncio.AbstractEventLoop,
+    client_session: aiohttp.ClientSession,
+    mock_requests: MockedRequests,
+):
+    tasks_before = asyncio.all_tasks(event_loop)  # This includes the test task
+    assert len(tasks_before) == 1
+
+    event_callback_mock = AsyncMock()
+
+    async with GitHubAPI(token=TOKEN, session=client_session) as github_api:
+        subscription_id = await github_api.repos.events.subscribe(
+            TEST_REPOSITORY_NAME, event_callback=event_callback_mock
+        )
+
+        assert subscription_id in github_api.repos.events._subscriptions
+        while not event_callback_mock.called:
+            await asyncio.sleep(0)
+
+        event: GitHubEventModel = event_callback_mock.call_args[0][0]
+        assert event.type == "PushEvent"
+
+        assert len(asyncio.all_tasks(event_loop) - tasks_before) == 1
+
+    assert len(asyncio.all_tasks(event_loop) - tasks_before) == 0
+
+
+@pytest.mark.asyncio
 async def test_subscription_exceptions_not_modified(
     github_api: GitHubAPI,
     mock_response: MockResponse,
@@ -56,7 +113,7 @@ async def test_subscription_exceptions_not_modified(
         error_callback=error_callback_mock,
     )
 
-    while not mock_requests.called:
+    while not mock_requests.called > 1:
         await asyncio.sleep(0)
 
     assert subscription_id in github_api.repos.events._subscriptions

--- a/tests/namespaces/test_events.py
+++ b/tests/namespaces/test_events.py
@@ -163,6 +163,7 @@ async def test_subscription_exceptions_not_found(
 async def test_subscription_exception(
     github_api: GitHubAPI,
     mock_response: MockResponse,
+    mock_requests: MockedRequests,
     wait_mock: None,
 ):
     event_callback_mock = AsyncMock()
@@ -177,6 +178,9 @@ async def test_subscription_exception(
     )
 
     while not error_callback_mock.called:
+        await asyncio.sleep(0)
+
+    while mock_requests.called < 10:
         await asyncio.sleep(0)
 
     assert not event_callback_mock.called

--- a/tests/namespaces/test_events.py
+++ b/tests/namespaces/test_events.py
@@ -70,7 +70,7 @@ async def test_stopping_all_subscriptions(github_api: GitHubAPI, mock_requests: 
 
     assert len(asyncio.all_tasks(github_api._client._loop) - tasks_before) == 2
 
-    await github_api.repos.events.stop_all_subscriptions()
+    await github_api.repos.events.unsubscribe_all()
     assert len(asyncio.all_tasks(github_api._client._loop) - tasks_before) == 0
 
 
@@ -109,6 +109,7 @@ async def test_subscription_exceptions_not_modified(
     mock_requests: MockedRequests,
     wait_mock: None,
 ):
+    mock_requests.clear()
     event_callback_mock = AsyncMock()
     error_callback_mock = AsyncMock()
 
@@ -120,7 +121,7 @@ async def test_subscription_exceptions_not_modified(
         error_callback=error_callback_mock,
     )
 
-    while not mock_requests.called > 1:
+    while mock_requests.called < 10:
         await asyncio.sleep(0)
 
     assert subscription_id in github_api.repos.events._subscriptions


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`GitHubEventsReposNamespace.unsubscribe` now returns a list of `asyncio.Task` that you can pass to `asyncio.wait()` to wait for all tasks to complete.
Alternatively, you can call `GitHubEventsReposNamespace.unsubscribe_all()`.

`GitHubEventsReposNamespace.unsubscribe_all()` is not called during `__aexit__`


## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionalit)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #154
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`make lint`)
- [x] Tests have been added to verify that the new code works.
